### PR TITLE
Opgelost: xml:base attribuut geeft NPE.

### DIFF
--- a/src/org/apache/cocoon/transformation/AbstractSAXPipelineTransformer.java
+++ b/src/org/apache/cocoon/transformation/AbstractSAXPipelineTransformer.java
@@ -54,6 +54,7 @@ public class AbstractSAXPipelineTransformer extends AbstractSAXTransformer {
     super.setup(resolver, objectModel, src, params);
     this.ourPrefix = null;
     this.namespaces.clear();
+    this.namespaces.add(new String[]{"xml", "http://www.w3.org/XML/1998/namespace"});
     this.recordingSAX = false;
   }
 

--- a/src/org/apache/cocoon/transformation/SparqlTransformer.java
+++ b/src/org/apache/cocoon/transformation/SparqlTransformer.java
@@ -195,7 +195,6 @@ public class SparqlTransformer extends AbstractSAXPipelineTransformer {
       throws ProcessingException, IOException, SAXException {
     HttpClient httpclient = new HttpClient();
     if (System.getProperty("http.proxyHost") != null) {
-  // getLogger().warn("PROXY: "+System.getProperty("http.proxyHost"));
       String nonProxyHostsRE = System.getProperty("http.nonProxyHosts", "");
       if (nonProxyHostsRE.length() > 0) {
         String[] pHosts = nonProxyHostsRE.replaceAll("\\.", "\\\\.").replaceAll("\\*", ".*").split("\\|");
@@ -205,7 +204,6 @@ public class SparqlTransformer extends AbstractSAXPipelineTransformer {
         }
         nonProxyHostsRE = nonProxyHostsRE.substring(1);
       }
-  // getLogger().warn("NONPROXY RE: "+nonProxyHostsRE);
       if (nonProxyHostsRE.length() == 0 || !url.matches(nonProxyHostsRE)) {
         try {
           HostConfiguration hostConfiguration = httpclient.getHostConfiguration();
@@ -274,6 +272,7 @@ public class SparqlTransformer extends AbstractSAXPipelineTransformer {
     try {
       // Execute the request.
       int responseCode;
+
       responseCode = httpclient.executeMethod(httpMethod);
       // Handle errors, if any.
       if (responseCode < 200 || responseCode >= 300) {


### PR DESCRIPTION
xml prefix en namespace mogen gedefinieerd worden, maar dat hoeft niet. In het geval het niet in t document gedefinieerd is gaf de AbstractSaxPipelineTransformer een NPE.
